### PR TITLE
Preprocess extend

### DIFF
--- a/micro_dl/config_preprocess.yml
+++ b/micro_dl/config_preprocess.yml
@@ -14,5 +14,5 @@ tile:
     depths: [3, 3, 1]
     mask_depth: 3
     data_format: 'channels_first'
-    save_tiled_masks: 'as_channel'
+    save_tiled_masks: True
     min_fraction: 0.25

--- a/micro_dl/config_preprocess.yml
+++ b/micro_dl/config_preprocess.yml
@@ -8,10 +8,10 @@ masks:
     str_elem_radius: 3
 do_tiling: True
 tile:
-    channels: [0, 5]
+    channels: [0, 1, 5]
     tile_size: [256, 256]
     step_size: [128, 128]
-    depths: [3, 1]
+    depths: [3, 3, 1]
     mask_depth: 3
     data_format: 'channels_first'
     save_tiled_masks: 'as_channel'

--- a/micro_dl/input/dataset.py
+++ b/micro_dl/input/dataset.py
@@ -1,4 +1,6 @@
 """Dataset classes"""
+
+import concurrent.futures
 import keras
 import numpy as np
 import os
@@ -156,6 +158,16 @@ class BaseDataSet(keras.utils.Sequence):
         # Stack images channels first
         return np.stack(image_volume)
 
+    def _get_batch(self, fname_tuple, normalize):
+        (fname, aug_idx) = fname_tuple
+        cur_vol = self._get_volume(fname.split(','), aug_idx)
+        # If target is boolean (segmentation masks), convert to float
+        if cur_vol.dtype == bool:
+            cur_vol = cur_vol.astype(np.float64)
+        if normalize:
+            cur_vol = (cur_vol - np.mean(cur_vol)) / np.std(cur_vol)
+        return cur_vol
+
     def __getitem__(self, index):
         """Get a batch of data
 
@@ -171,32 +183,42 @@ class BaseDataSet(keras.utils.Sequence):
         if end_idx >= self.num_samples:
             end_idx = self.num_samples
 
-        input_image = []
-        target_image = []
+        input_fnames = []
+        target_fnames = []
+        aug_ids = []
+        norm_output = self.model_task is not 'segmentation' and self.normalize
+
         aug_idx = 0
         for idx in range(start_idx, end_idx, 1):
-            cur_input_fnames = self.input_fnames.iloc[self.row_idx[idx]]
-            cur_target_fnames = self.target_fnames.iloc[self.row_idx[idx]]
+            input_fnames.append(self.input_fnames.iloc[self.row_idx[idx]])
+            target_fnames.append(self.target_fnames.iloc[self.row_idx[idx]])
             # Select select int randomly that will represent augmentation type
             if self.augmentations:
                 aug_idx = np.random.choice([0, 1, 2, 3, 4, 5], 1)
+            aug_ids.append(aug_idx)
 
-            cur_input = self._get_volume(cur_input_fnames.split(','),
-                                         aug_idx)
-            cur_target = self._get_volume(cur_target_fnames.split(','),
-                                          aug_idx)
-            # If target is boolean (segmentation masks), convert to float
-            if cur_target.dtype == bool:
-                cur_target = cur_target.astype(np.float64)
-            if self.normalize:
-                cur_input = (cur_input - np.mean(cur_input)) /\
-                             np.std(cur_input)
-                # Only normalize target if we're dealing with regression
-                if self.model_task is not 'segmentation' and self.normalize:
-                    cur_target = (cur_target - np.mean(cur_target)) /\
-                                 np.std(cur_target)
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            future_input = {executor.submit(
+                self._get_batch,
+                fname_tuple,
+                self.normalize):
+                fname_tuple for fname_tuple in zip(input_fnames, aug_ids)}
+        input_image = []
+        for future in concurrent.futures.map(future_input):
+            cur_input = future.result()
             input_image.append(cur_input)
+
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            future_target = {executor.submit(
+                self._get_batch,
+                fname_tuple,
+                norm_output):
+                fname_tuple for fname_tuple in zip(target_fnames, aug_ids)}
+        target_image = []
+        for future in concurrent.futures.map(future_target):
+            cur_target = future.result()
             target_image.append(cur_target)
+
         input_image = np.stack(input_image)
         target_image = np.stack(target_image)
         return input_image, target_image

--- a/micro_dl/input/tile_images.py
+++ b/micro_dl/input/tile_images.py
@@ -1,5 +1,6 @@
 """Tile images for training"""
 
+import concurrent.futures
 import numpy as np
 import os
 import pandas as pd
@@ -104,7 +105,7 @@ class ImageTiler:
         try:
             os.makedirs(self.tile_dir, exist_ok=False)
         except FileExistsError as e:
-            print("Tile dir exists. Only add untiled channels.", e)
+            print("Tile dir exists. Only add untiled channels.")
             self.tiles_exist = True
 
         self.tile_mask_dir = None
@@ -122,7 +123,7 @@ class ImageTiler:
         self.time_ids = metadata_ids['time_ids']
         self.slice_ids = metadata_ids['slice_ids']
         self.pos_ids = metadata_ids['pos_ids']
-        # If more than one depth is specified, they must match channel ids
+        # If more than one depth is specified, length must match channel ids
         if isinstance(self.depths, list):
             assert len(self.depths) == len(self.channel_ids),\
              "depths ({}) and channels ({}) length mismatch".format(
@@ -133,6 +134,7 @@ class ImageTiler:
             # Convert channels + depths to dict for lookup
             self.channel_depth = dict(zip(self.channel_ids, self.depths))
         else:
+            # If depth is scalar, make depth the same for all channels
             max_depth = max(self.depths, self.mask_depth)
             self.channel_depth = dict(zip(
                 self.channel_ids,
@@ -183,8 +185,12 @@ class ImageTiler:
          tiles
         :return dataframe tiled_metadata: Metadata with rows added to it
         """
-        for i, data_tuple in enumerate(tiled_data):
-            rcsl_idx = data_tuple[0]
+        flip = False
+        if self.data_format == 'channels_first' and \
+            len(tiled_data[0][1].shape) > 2:
+            flip = True
+        for i, data_list in enumerate(tiled_data):
+            rcsl_idx = data_list[0]
             file_name = aux_utils.get_im_name(
                 time_idx=time_idx,
                 channel_idx=channel_idx,
@@ -192,14 +198,7 @@ class ImageTiler:
                 pos_idx=pos_idx,
                 extra_field=rcsl_idx,
             )
-            tile = data_tuple[1]
-            # Check and potentially flip dimensions for 3D data
-            if self.data_format == 'channels_first' and len(tile.shape) > 2:
-                tile = np.transpose(tile, (2, 0, 1))
-            np.save(os.path.join(save_dir, file_name),
-                    tile,
-                    allow_pickle=True,
-                    fix_imports=True)
+            tiled_data[i][0] = os.path.join(save_dir, file_name)
             tile_idx = tile_indices[i]
             if tiled_metadata is not None:
                 tiled_metadata = tiled_metadata.append(
@@ -213,6 +212,10 @@ class ImageTiler:
                      },
                     ignore_index=True,
                 )
+        # Numpy save is really slow, use threading
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            {executor.submit(image_utils.write_tile, tile, flip):
+             tile for tile in tiled_data}
         return tiled_metadata
 
     def _get_flat_field(self, channel_idx):
@@ -231,6 +234,44 @@ class ImageTiler:
                 )
             )
         return flat_field_im
+
+    def _get_tiled_data(self):
+        """
+        If tile directory already exists, check which channels have been
+        processed and only tile new channels.
+
+        :return dataframe tiled_meta: Metadata with previously tiled channels
+        :return list of lists tile_indices: Nbr tiles x 4 indices with row
+        start + stop and column start + stop indices
+        """
+        if self.tiles_exist:
+            tiled_meta = aux_utils.read_meta(self.tile_dir)
+            # Find untiled channels
+            tiled_channels = np.unique(tiled_meta['channel_idx'])
+            new_channels = list(set(self.channel_ids) - set(tiled_channels))
+            if len(new_channels) == 0:
+                print('All channels in config have already been tiled')
+                return
+            self.channel_ids = new_channels
+            # Get tile indices from one channel only
+            c = tiled_meta['channel_idx'] == tiled_channels[0]
+            z = tiled_meta['slice_idx'] == self.slice_ids[0]
+            p = tiled_meta['pos_idx'] == self.pos_ids[0]
+            t = tiled_meta['time_idx'] == self.time_ids[0]
+            channel_meta = tiled_meta[c & z & p & t]
+            # Get tile_indices
+            tile_indices = pd.concat([
+                channel_meta['row_start'],
+                channel_meta['row_start'].add(self.tile_size[0]),
+                channel_meta['col_start'],
+                channel_meta['col_start'].add(self.tile_size[1]),
+            ], axis=1)
+            # Match list format similar to tile_image
+            tile_indices = tile_indices.values.tolist()
+        else:
+            tiled_meta = self._get_dataframe()
+            tile_indices = None
+        return tiled_meta, tile_indices
 
     def _get_dataframe(self):
         """
@@ -262,14 +303,9 @@ class ImageTiler:
         ['time_idx', 'channel_idx', 'pos_idx','slice_idx', 'file_name']
         for all the tiles
         """
-        if self.tiles_exist:
-            tiled_metadata = aux_utils.read_meta(self.tile_dir)
-            # Do some logic on what channels have been tiled
-            # Get indices for untiled channels
-            # Get tile_indices
-        else:
-            tiled_metadata = self._get_dataframe()
-        tile_indices = None
+        # Get or create tiled metadata and tile indices
+        tiled_metadata, tile_indices = self._get_tiled_data()
+
         for channel_idx in self.channel_ids:
             # Perform flatfield correction if flatfield dir is specified
             flat_field_im = self._get_flat_field(channel_idx=channel_idx)
@@ -351,9 +387,9 @@ class ImageTiler:
 
     def tile_mask_stack(self,
                         mask_dir=None,
-                        save_tiled_masks=None,
                         mask_channel=None,
                         min_fraction=None,
+                        save_tiled_masks=True,
                         isotropic=False):
         """
         Tiles images in the specified channels assuming there are masks
@@ -364,26 +400,14 @@ class ImageTiler:
         'slice_idx', 'file_name'] for all the tiles
 
         :param str mask_dir: Directory containing masks
-        :param str save_tiled_masks: How/if to save mask tiles. If None, don't
-            save masks.
-            If 'as_channel', save masked tiles as a channel given
-            by mask_channel in tile_dir.
-            If 'as_masks', create a new tile_mask_dir and save them there
+        :param bool save_tiled_masks: How/if to save mask tiles. If true,
+         save masked tiles as a channel given by mask_channel in tile_dir.
         :param str mask_channel: Channel number assigned to mask
         :param float min_fraction: Minimum fraction of foreground in tiled masks
         :param bool isotropic: Indicator of isotropy
         """
-        if save_tiled_masks == 'as_masks':
-            self.tile_mask_dir = os.path.join(
-                self.output_dir,
-                'mask_' + '-'.join(map(str, self.channel_ids)) +
-                self.str_tile_step,
-            )
-            os.makedirs(self.tile_mask_dir, exist_ok=True)
-        elif save_tiled_masks == 'as_channel':
-            self.tile_mask_dir = self.tile_dir
-
-        tiled_metadata = self._get_dataframe()
+        # Get or create tiled metadata and tile indices
+        tiled_metadata, tile_indices = self._get_tiled_data()
         mask_metadata = self._get_dataframe()
         # Load flatfield images if flatfield dir is specified
         flat_field_im = None
@@ -395,33 +419,35 @@ class ImageTiler:
         for slice_idx in self.slice_ids:
             for time_idx in self.time_ids:
                 for pos_idx in np.unique(self.frames_metadata["pos_idx"]):
-                    # Since masks are generated across channels, we only need
-                    # load them once across channels
-                    mask_image = self._get_mask(
-                        time_idx=time_idx,
-                        mask_channel=mask_channel,
-                        slice_idx=slice_idx,
-                        pos_idx=pos_idx,
-                        mask_dir=mask_dir)
-                    tiled_mask_data, tile_indices = image_utils.tile_image(
-                        input_image=mask_image,
-                        min_fraction=min_fraction,
-                        tile_size=self.tile_size,
-                        step_size=self.step_size,
-                        isotropic=isotropic,
-                        return_index=True,
-                    )
-                    # Loop through all the mask tiles, write tiled masks
-                    mask_metadata = self._write_tiled_data(
-                        tiled_data=tiled_mask_data,
-                        save_dir=self.tile_mask_dir,
-                        time_idx=time_idx,
-                        channel_idx=mask_channel,
-                        slice_idx=slice_idx,
-                        pos_idx=pos_idx,
-                        tile_indices=tile_indices,
-                        tiled_metadata=mask_metadata,
-                    )
+                    # Evaluate mask, then channels. The masks will influence
+                    # tiling indices, so it's not allowed to add masks to existing
+                    # tile datasets (indices will be retrieved from existing meta)
+                    if not self.tiles_exist:
+                        mask_image = self._get_mask(
+                            time_idx=time_idx,
+                            mask_channel=mask_channel,
+                            slice_idx=slice_idx,
+                            pos_idx=pos_idx,
+                            mask_dir=mask_dir)
+                        tiled_mask_data, tile_indices = image_utils.tile_image(
+                            input_image=mask_image,
+                            min_fraction=min_fraction,
+                            tile_size=self.tile_size,
+                            step_size=self.step_size,
+                            isotropic=isotropic,
+                            return_index=True,
+                        )
+                        # Loop through all the mask tiles, write tiled masks
+                        mask_metadata = self._write_tiled_data(
+                            tiled_data=tiled_mask_data,
+                            save_dir=self.tile_dir,
+                            time_idx=time_idx,
+                            channel_idx=mask_channel,
+                            slice_idx=slice_idx,
+                            pos_idx=pos_idx,
+                            tile_indices=tile_indices,
+                            tiled_metadata=mask_metadata,
+                        )
                     # Loop through all channels and tile from indices
                     for i, channel_idx in enumerate(self.channel_ids):
 
@@ -458,15 +484,10 @@ class ImageTiler:
                         )
 
         # Finally, save all the metadata
-        if self.tile_mask_dir == self.tile_dir:
+        if save_tiled_masks:
             tiled_metadata = tiled_metadata.append(
                 mask_metadata,
                 ignore_index=True,
-            )
-        else:
-            mask_metadata.to_csv(
-                os.path.join(self.tile_mask_dir, "frames_meta.csv"),
-                sep=",",
             )
         tiled_metadata = tiled_metadata.sort_values(by=['file_name'])
         tiled_metadata.to_csv(

--- a/micro_dl/utils/aux_utils.py
+++ b/micro_dl/utils/aux_utils.py
@@ -266,7 +266,7 @@ def read_meta(input_dir, meta_fname='frames_meta.csv'):
     try:
         frames_metadata = pd.read_csv(meta_fname[0])
     except IOError as e:
-        e.args += 'cannot read split image info'
+        e.args += 'cannot read metadata csv file'
         raise
     return frames_metadata
 

--- a/micro_dl/utils/image_utils.py
+++ b/micro_dl/utils/image_utils.py
@@ -245,7 +245,7 @@ def tile_image(input_image,
 
     assert len(tile_size) == len(step_size),\
         "Tile {} and step size {} mismatch".format(tile_size, step_size)
-    assert np.all(step_size <= tile_size).\
+    assert np.all(step_size <= tile_size),\
         "Step size {} > tile size {}".format(step_size, tile_size)
     assert np.all(tile_size) > 0,\
         "Tile size must be > 0, not {}".format(tile_size)

--- a/micro_dl/utils/image_utils.py
+++ b/micro_dl/utils/image_utils.py
@@ -313,15 +313,15 @@ def crop_at_indices(input_image, crop_indices, isotropic=False):
     """
 
     n_dim = len(input_image.shape)
-    cropped_img_list = []
+    tiles_list = []
     im_depth = input_image.shape[2]
     for cur_idx in crop_indices:
         img_id = 'r{}-{}_c{}-{}'.format(cur_idx[0], cur_idx[1],
                                         cur_idx[2], cur_idx[3])
 
         cropped_img = input_image[cur_idx[0]: cur_idx[1],
-                      cur_idx[2]: cur_idx[3], ...]
-        if n_dim == 3 and len(cur_idx) == 6:
+                                  cur_idx[2]: cur_idx[3], ...]
+        if n_dim == 3:
             img_id = '{}_sl{}-{}'.format(img_id, 0, im_depth)
 
             if isotropic:
@@ -329,8 +329,19 @@ def crop_at_indices(input_image, crop_indices, isotropic=False):
                 isotropic_shape = [img_shape[0], ] * len(img_shape)
                 cropped_img = resize_image(cropped_img, isotropic_shape)
 
-        cropped_img_list.append((img_id, cropped_img))
-    return cropped_img_list
+        tiles_list.append([img_id, cropped_img])
+    return tiles_list
+
+
+def write_tile(file_name_list, flip):
+    """
+    Write tile function that can be called using threading.
+    :param list file_name_list: [file path, tile]
+    """
+    [file_name, tile] = file_name_list
+    if flip:
+        tile = np.transpose(tile, (2, 0, 1))
+    np.save(file_name, tile,  allow_pickle=True, fix_imports=True)
 
 
 def create_mask(input_image, str_elem_size=3):

--- a/micro_dl/utils/image_utils.py
+++ b/micro_dl/utils/image_utils.py
@@ -243,12 +243,12 @@ def tile_image(input_image,
         if len(step_size) == 2:
             step_size.append(im_shape[2])
 
-    check_1 = len(tile_size) == len(step_size)
-    check_2 = np.all(step_size <= tile_size)
-    check_3 = np.all(tile_size) > 0
-    assert check_1 and check_2 and check_3,\
-        "Tiling not valid with tile size {} and step {}".format(
-            tile_size, step_size)
+    assert len(tile_size) == len(step_size),\
+        "Tile {} and step size {} mismatch".format(tile_size, step_size)
+    assert np.all(step_size <= tile_size).\
+        "Step size {} > tile size {}".format(step_size, tile_size)
+    assert np.all(tile_size) > 0,\
+        "Tile size must be > 0, not {}".format(tile_size)
 
     n_rows = input_image.shape[0]
     n_cols = input_image.shape[1]

--- a/micro_dl/utils/image_utils.py
+++ b/micro_dl/utils/image_utils.py
@@ -288,14 +288,14 @@ def tile_image(input_image,
                         cropped_img = resize_image(cropped_img,
                                                    isotropic_shape)
                     if use_tile(cropped_img, min_fraction):
-                        cropped_image_list.append((img_id, cropped_img))
+                        cropped_image_list.append([img_id, cropped_img])
                         cropping_index.append(cur_index)
             else:
                 cur_index = (row, row + tile_size[0], col, col + tile_size[1])
                 cropped_img = input_image[row: row + tile_size[0],
                                           col: col + tile_size[1]]
                 if use_tile(cropped_img, min_fraction):
-                    cropped_image_list.append((img_id, cropped_img))
+                    cropped_image_list.append([img_id, cropped_img])
                     cropping_index.append(cur_index)
     if return_index:
         return cropped_image_list, cropping_index

--- a/tests/input/dataset_tests.py
+++ b/tests/input/dataset_tests.py
@@ -208,10 +208,12 @@ class TestBaseDataSet(unittest.TestCase):
         for i in range(2):
             # only compare self.im
             im_test = np.squeeze(im_in[i, ...])
+            print(i, im_test[0, ...])
             im_expected = self.data_inst._augment_image(
                 self.im + shuf_ids[i],
                 augmentations[i],
             )
+            print(im_expected[0, ...])
             np.testing.assert_array_equal(im_test, im_expected)
 
     def test__getitem__normalized(self):

--- a/tests/input/tile_image_tests.py
+++ b/tests/input/tile_image_tests.py
@@ -150,8 +150,11 @@ class TestImageTiler(unittest.TestCase):
         nose.tools.assert_equal(self.tile_inst.get_tile_mask_dir(), None)
 
     def test_write_tiled_data(self):
-        tiled_data = [('r0-5_c0-5_sl0-3', np.zeros((5, 5, 3), dtype=np.float)),
-                      ('r4-9_c0-5_sl0-3', np.ones((5, 5, 3), dtype=np.float))]
+        tile = np.zeros((5, 5, 3), dtype=np.float)
+        tile[..., 1] = 1
+        tile[..., 2] = 2
+        tiled_data = [['r0-5_c0-5_sl0-3', tile],
+                      ['r4-9_c0-5_sl0-3', 5 * tile]]
         tiled_metadata = self.tile_inst._get_dataframe()
         tile_indices = [(0, 5, 0, 5), (4, 9, 0, 5)]
         tile_dir = self.tile_inst.get_tile_dir()
@@ -398,8 +401,11 @@ class TestImageMaskTiler(unittest.TestCase):
         )
 
     def test_write_tiled_data(self):
-        tiled_data = [('r0-5_c0-5_sl0-3', np.zeros((5, 5, 3), dtype=np.float)),
-                      ('r5-10_c0-5_sl0-3', np.ones((5, 5, 3), dtype=np.float))]
+        tile = np.zeros((5, 5, 3), dtype=np.float)
+        tile[..., 1] = 1
+        tile[..., 2] = 2
+        tiled_data = [['r0-5_c0-5_sl0-3', tile],
+                      ['r5-10_c0-5_sl0-3', 5 * tile]]
         tiled_metadata = self.tile_inst._get_dataframe()
         tile_indices = [(0, 5, 0, 5), (4, 9, 0, 5)]
         tile_dir = self.tile_inst.get_tile_dir()

--- a/tests/input/tile_image_tests.py
+++ b/tests/input/tile_image_tests.py
@@ -469,13 +469,11 @@ class TestImageMaskTiler(unittest.TestCase):
         nose.tools.assert_equal(flat_field_im, None)
 
     def test_tile_mask_stack(self):
-        import glob
-        print(glob.glob(self.mask_dir + '/*'))
         self.tile_inst.tile_mask_stack(
             min_fraction=0.0,
             mask_dir=self.mask_dir,
             mask_channel=self.mask_channel,
-            save_tiled_masks='as_channel',
+            save_tiled_masks=True,
             )
         # Read and validate the saved metadata
         tile_dir = self.tile_inst.get_tile_dir()


### PR DESCRIPTION
I extended the functionality of tiling, so instead of throwing an error if tile_dir exists, it will check which channels that are already tiled and add only those in the config that have not been tiled already.

If adding to existing dir, it will retrieve tile row and column start locations from existing metadata csv, because new tiles need to match existing data.

Also added threading using concurrent.futures, it cut tiling time in half.