### PR TITLE
 fix for mask generation from >1 channel

### DIFF
--- a/micro_dl/cli/preprocess_script.py
+++ b/micro_dl/cli/preprocess_script.py
@@ -112,7 +112,8 @@ def generate_masks(params_dict,
                    flat_field_dir,
                    str_elem_radius,
                    mask_type,
-                   mask_out_channel):
+                   mask_out_channel,
+                   mask_ext):
     """Generate masks per image or volume
 
     :param dict params_dict: dict with keys: input_dir, output_dir, time_ids,
@@ -124,6 +125,8 @@ def generate_masks(params_dict,
      opening
     :param str mask_type: string to map to masking function. otsu or uniform
     :param int mask_out_channel: channel num assigned to mask channel. I
+    :param str mask_ext: 'npy' or 'png'. Save the mask as uint8 PNG or
+         NPY files
     :return:
      str mask_dir: dir with created masks
      int mask_out_channel: channel number assigned to masks
@@ -144,7 +147,8 @@ def generate_masks(params_dict,
         uniform_struct=params_dict['uniform_struct'],
         num_workers=params_dict['num_workers'],
         mask_type=mask_type,
-        mask_out_channel=mask_out_channel
+        mask_out_channel=mask_out_channel,
+        mask_ext=mask_ext
     )
 
     correct_flat_field = False
@@ -306,12 +310,17 @@ def pre_process(pp_config, req_params_dict):
             mask_type = 'otsu'
             if 'mask_type' in pp_config['masks']:
                 mask_type = pp_config['masks']['mask_type']
+            mask_ext = 'png'
+            if 'mask_ext' in pp_config['masks']:
+                mask_ext = pp_config['masks']['mask_ext']
             mask_dir, mask_out_channel = generate_masks(req_params_dict,
                                                         mask_from_channel,
                                                         flat_field_dir,
                                                         str_elem_radius,
                                                         mask_type,
-                                                        mask_out_channel)
+                                                        mask_out_channel,
+                                                        mask_ext)
+            pp_config['masks']['created_mask_dir'] = mask_dir
         elif 'mask_dir' in pp_config['masks']:
             mask_dir = pp_config['masks']['mask_dir']
             # Get preexisting masks from directory and match to input dir

--- a/micro_dl/cli/preprocess_script.py
+++ b/micro_dl/cli/preprocess_script.py
@@ -310,7 +310,7 @@ def pre_process(pp_config, req_params_dict):
             mask_type = 'otsu'
             if 'mask_type' in pp_config['masks']:
                 mask_type = pp_config['masks']['mask_type']
-            mask_ext = 'png'
+            mask_ext = 'npy'
             if 'mask_ext' in pp_config['masks']:
                 mask_ext = pp_config['masks']['mask_ext']
             mask_dir, mask_out_channel = generate_masks(req_params_dict,

--- a/micro_dl/preprocessing/generate_masks.py
+++ b/micro_dl/preprocessing/generate_masks.py
@@ -22,7 +22,7 @@ class MaskProcessor:
                  num_workers=4,
                  mask_type='otsu',
                  mask_out_channel=None,
-                 mask_ext='png'):
+                 mask_ext='npy'):
         """
         :param str input_dir: Directory with image frames
         :param str output_dir: Base output directory

--- a/micro_dl/preprocessing/generate_masks.py
+++ b/micro_dl/preprocessing/generate_masks.py
@@ -21,7 +21,8 @@ class MaskProcessor:
                  uniform_struct=True,
                  num_workers=4,
                  mask_type='otsu',
-                 mask_out_channel=None):
+                 mask_out_channel=None,
+                 save_mask_fig=False):
         """
         :param str input_dir: Directory with image frames
         :param str output_dir: Base output directory
@@ -44,6 +45,8 @@ class MaskProcessor:
         :param int mask_out_channel: channel num assigned to mask channel. If
          resizing images on a subset of channels, frames_meta is from resize
          dir, which could lead to wrong mask channel being assigned.
+        :param bool save_mask_fig: save the mask as uint8 PNG in addition to
+            NPY files for visualization
         """
 
         self.input_dir = input_dir
@@ -87,6 +90,7 @@ class MaskProcessor:
         assert mask_type in ['otsu', 'unimodal'], \
             'Masking method invalid, Otsu and unimodal are currently supported'
         self.mask_type = mask_type
+        self.save_mask_fig = save_mask_fig
 
     def get_mask_dir(self):
         """
@@ -186,7 +190,8 @@ class MaskProcessor:
                                     pos_idx,
                                     slice_idx,
                                     self.int2str_len,
-                                    self.mask_type)
+                                    self.mask_type,
+                                    self.save_mask_fig)
                         fn_args.append(cur_args)
         else:
             for tp_idx, tp_dict in self.nested_id_dict.items():
@@ -208,7 +213,8 @@ class MaskProcessor:
                                     pos_idx,
                                     sl_idx,
                                     self.int2str_len,
-                                    self.mask_type)
+                                    self.mask_type,
+                                    self.save_mask_fig)
                         fn_args.append(cur_args)
 
         mask_meta_list = mp_create_save_mask(fn_args, self.num_workers)

--- a/micro_dl/preprocessing/generate_masks.py
+++ b/micro_dl/preprocessing/generate_masks.py
@@ -22,7 +22,7 @@ class MaskProcessor:
                  num_workers=4,
                  mask_type='otsu',
                  mask_out_channel=None,
-                 save_mask_fig=False):
+                 mask_ext='png'):
         """
         :param str input_dir: Directory with image frames
         :param str output_dir: Base output directory
@@ -45,8 +45,8 @@ class MaskProcessor:
         :param int mask_out_channel: channel num assigned to mask channel. If
          resizing images on a subset of channels, frames_meta is from resize
          dir, which could lead to wrong mask channel being assigned.
-        :param bool save_mask_fig: save the mask as uint8 PNG in addition to
-            NPY files for visualization
+        :param str mask_ext: 'npy' or 'png'. Save the mask as uint8 PNG or
+         NPY files
         """
 
         self.input_dir = input_dir
@@ -90,7 +90,7 @@ class MaskProcessor:
         assert mask_type in ['otsu', 'unimodal'], \
             'Masking method invalid, Otsu and unimodal are currently supported'
         self.mask_type = mask_type
-        self.save_mask_fig = save_mask_fig
+        self.mask_ext = mask_ext
 
     def get_mask_dir(self):
         """
@@ -191,7 +191,7 @@ class MaskProcessor:
                                     slice_idx,
                                     self.int2str_len,
                                     self.mask_type,
-                                    self.save_mask_fig)
+                                    self.mask_ext)
                         fn_args.append(cur_args)
         else:
             for tp_idx, tp_dict in self.nested_id_dict.items():
@@ -214,7 +214,7 @@ class MaskProcessor:
                                     sl_idx,
                                     self.int2str_len,
                                     self.mask_type,
-                                    self.save_mask_fig)
+                                    self.mask_ext)
                         fn_args.append(cur_args)
 
         mask_meta_list = mp_create_save_mask(fn_args, self.num_workers)

--- a/micro_dl/utils/mp_utils.py
+++ b/micro_dl/utils/mp_utils.py
@@ -35,7 +35,8 @@ def create_save_mask(input_fnames,
                      mask_type,
                      mask_ext):
     """Create and save mask
-
+    When >1 channel are used to generate the mask, mask of each channel is
+    generated then added together
     :param tuple input_fnames: tuple of input fnames with full path
     :param str flat_field_fname: fname of flat field image
     :param int str_elem_radius: size of structuring element used for binary

--- a/micro_dl/utils/mp_utils.py
+++ b/micro_dl/utils/mp_utils.py
@@ -32,7 +32,8 @@ def create_save_mask(input_fnames,
                      pos_idx,
                      slice_idx,
                      int2str_len,
-                     mask_type):
+                     mask_type,
+                     save_mask_fig):
     """Create and save mask
 
     :param tuple input_fnames: tuple of input fnames with full path
@@ -47,6 +48,8 @@ def create_save_mask(input_fnames,
     :param int int2str_len: Length of str when converting ints
     :param str mask_type: thresholding type used for masking or str to map to
      masking function
+    :param bool save_mask_fig: save the mask as uint8 PNG in addition to
+         NPY files for visualization
     :return dict cur_meta for each mask
     """
 
@@ -77,13 +80,18 @@ def create_save_mask(input_fnames,
             mask,
             allow_pickle=True,
             fix_imports=True)
+
     cur_meta = {'channel_idx': mask_channel_idx,
                 'slice_idx': slice_idx,
                 'time_idx': time_idx,
                 'pos_idx': pos_idx,
                 'file_name': file_name}
+    if save_mask_fig:
+        file_name = file_name[:-3] + 'png'
+        # Covert mask to uint8
+        mask = mask.astype(np.uint8) * (2 ** 8 - 1)
+        cv2.imwrite(os.path.join(mask_dir, file_name), mask)
     return cur_meta
-
 
 def mp_tile_save(fn_args, workers):
     """Tile and save with multiprocessing

--- a/micro_dl/utils/mp_utils.py
+++ b/micro_dl/utils/mp_utils.py
@@ -33,7 +33,7 @@ def create_save_mask(input_fnames,
                      slice_idx,
                      int2str_len,
                      mask_type,
-                     save_mask_fig):
+                     mask_ext):
     """Create and save mask
 
     :param tuple input_fnames: tuple of input fnames with full path
@@ -48,8 +48,8 @@ def create_save_mask(input_fnames,
     :param int int2str_len: Length of str when converting ints
     :param str mask_type: thresholding type used for masking or str to map to
      masking function
-    :param bool save_mask_fig: save the mask as uint8 PNG in addition to
-         NPY files for visualization
+    :param str mask_ext: 'npy' or 'png'. Save the mask as uint8 PNG or
+         NPY files
     :return dict cur_meta for each mask
     """
 
@@ -75,22 +75,25 @@ def create_save_mask(input_fnames,
                                       slice_idx=slice_idx,
                                       pos_idx=pos_idx,
                                       int2str_len=int2str_len)
-    # Save mask for given channels, mask is 2D
-    np.save(os.path.join(mask_dir, file_name),
-            mask,
-            allow_pickle=True,
-            fix_imports=True)
 
+    if mask_ext == 'npy':
+        # Save mask for given channels, mask is 2D
+        np.save(os.path.join(mask_dir, file_name),
+                mask,
+                allow_pickle=True,
+                fix_imports=True)
+    elif mask_ext == 'png':
+        file_name = file_name[:-3] + 'png'
+        # Covert mask to uint8
+        mask = mask.astype(np.uint8) * (2 ** 8 - 1)
+        cv2.imwrite(os.path.join(mask_dir, file_name), mask)
+    else:
+        raise ValueError("mask_ext can only be 'npy' or 'png'")
     cur_meta = {'channel_idx': mask_channel_idx,
                 'slice_idx': slice_idx,
                 'time_idx': time_idx,
                 'pos_idx': pos_idx,
                 'file_name': file_name}
-    if save_mask_fig:
-        file_name = file_name[:-3] + 'png'
-        # Covert mask to uint8
-        mask = mask.astype(np.uint8) * (2 ** 8 - 1)
-        cv2.imwrite(os.path.join(mask_dir, file_name), mask)
     return cur_meta
 
 def mp_tile_save(fn_args, workers):

--- a/micro_dl/utils/tile_utils.py
+++ b/micro_dl/utils/tile_utils.py
@@ -38,15 +38,8 @@ def read_imstack(input_fnames,
                 flat_field_image=flat_field_image,
             )
         im_stack.append(im)
-    if len(im.shape) == 3:
-        if len(input_fnames) == 1:
-            # multiple 3d images could be passed for creating masks from their
-            # sum
-            input_image = im
-        elif len(input_fnames) > 1:
-            input_image = np.stack(im_stack, axis=3)
-    else:
-        input_image = np.stack(im_stack, axis=2)
+
+    input_image = np.stack(im_stack, axis=-1)
     if not is_mask:
         if hist_clip_limits is not None:
             input_image = normalize.hist_clipping(

--- a/micro_dl/utils/tile_utils.py
+++ b/micro_dl/utils/tile_utils.py
@@ -40,6 +40,9 @@ def read_imstack(input_fnames,
         im_stack.append(im)
 
     input_image = np.stack(im_stack, axis=-1)
+    # remove singular dimension for 3D images
+    if len(input_image.shape) > 3:
+        input_image = np.squeeze(input_image)
     if not is_mask:
         if hist_clip_limits is not None:
             input_image = normalize.hist_clipping(

--- a/tests/utils/mp_utils_tests.py
+++ b/tests/utils/mp_utils_tests.py
@@ -10,6 +10,7 @@ import warnings
 
 import micro_dl.utils.aux_utils as aux_utils
 import micro_dl.utils.mp_utils as mp_utils
+import micro_dl.utils.image_utils as image_utils
 from micro_dl.utils.masks import create_otsu_mask
 
 
@@ -117,11 +118,13 @@ class TestMpUtils(unittest.TestCase):
                 slice_idx=sl_idx,
                 int2str_len=3,
                 mask_type='otsu',
+                mask_ext='png'
             )
             fname = aux_utils.get_im_name(time_idx=self.time_ids,
                                           channel_idx=3,
                                           slice_idx=sl_idx,
-                                          pos_idx=self.pos_ids)
+                                          pos_idx=self.pos_ids,
+                                          ext='.png')
             exp_meta = {'channel_idx': 3,
                         'slice_idx': sl_idx,
                         'time_idx': 0,
@@ -132,7 +135,8 @@ class TestMpUtils(unittest.TestCase):
             op_fname = os.path.join(self.output_dir, fname)
             nose.tools.assert_equal(os.path.exists(op_fname),
                                     True)
-            mask_image = np.load(op_fname)
+
+            mask_image = image_utils.read_image(op_fname)
             input_image = (self.sph_object[:, :, sl_idx] +
                            self.rec_object[:, :, sl_idx])
             numpy.testing.assert_array_equal(

--- a/tests/utils/mp_utils_tests.py
+++ b/tests/utils/mp_utils_tests.py
@@ -139,11 +139,13 @@ class TestMpUtils(unittest.TestCase):
             mask_image = image_utils.read_image(op_fname)
             if mask_image.dtype != bool:
                 mask_image = mask_image > 0
-            input_image = (self.sph_object[:, :, sl_idx] +
+            input_image = (self.sph_object[:, :, sl_idx],
                            self.rec_object[:, :, sl_idx])
+            mask_stack = np.stack(create_otsu_mask(input_image[0], str_elem_size=1),
+                                  create_otsu_mask(input_image[1], str_elem_size=1))
+            mask_exp = np.any(mask_stack)
             numpy.testing.assert_array_equal(
-                mask_image,
-                create_otsu_mask(input_image, str_elem_size=1)
+                mask_image, mask_exp
             )
 
     def test_rescale_vol_and_save(self):

--- a/tests/utils/mp_utils_tests.py
+++ b/tests/utils/mp_utils_tests.py
@@ -141,9 +141,9 @@ class TestMpUtils(unittest.TestCase):
                 mask_image = mask_image > 0
             input_image = (self.sph_object[:, :, sl_idx],
                            self.rec_object[:, :, sl_idx])
-            mask_stack = np.stack(create_otsu_mask(input_image[0], str_elem_size=1),
-                                  create_otsu_mask(input_image[1], str_elem_size=1))
-            mask_exp = np.any(mask_stack)
+            mask_stack = np.stack([create_otsu_mask(input_image[0], str_elem_size=1),
+                                  create_otsu_mask(input_image[1], str_elem_size=1)])
+            mask_exp = np.any(mask_stack, axis=0)
             numpy.testing.assert_array_equal(
                 mask_image, mask_exp
             )

--- a/tests/utils/mp_utils_tests.py
+++ b/tests/utils/mp_utils_tests.py
@@ -137,6 +137,8 @@ class TestMpUtils(unittest.TestCase):
                                     True)
 
             mask_image = image_utils.read_image(op_fname)
+            if mask_image.dtype != bool:
+                mask_image = mask_image > 0
             input_image = (self.sph_object[:, :, sl_idx] +
                            self.rec_object[:, :, sl_idx])
             numpy.testing.assert_array_equal(

--- a/tests/utils/tile_utils_tests.py
+++ b/tests/utils/tile_utils_tests.py
@@ -102,7 +102,7 @@ class TestTileUtils(unittest.TestCase):
 
         # read a 3D image
         im_stack = tile_utils.read_imstack([self.sph_fname])
-        numpy.testing.assert_equal(im_stack.shape, (32, 32, 8, 1))
+        numpy.testing.assert_equal(im_stack.shape, (32, 32, 8))
 
         # read multiple 3D images
         im_stack = tile_utils.read_imstack((self.sph_fname, self.sph_fname))

--- a/tests/utils/tile_utils_tests.py
+++ b/tests/utils/tile_utils_tests.py
@@ -102,7 +102,7 @@ class TestTileUtils(unittest.TestCase):
 
         # read a 3D image
         im_stack = tile_utils.read_imstack([self.sph_fname])
-        numpy.testing.assert_equal(im_stack.shape, (32, 32, 8))
+        numpy.testing.assert_equal(im_stack.shape, (32, 32, 8, 1))
 
         # read multiple 3D images
         im_stack = tile_utils.read_imstack((self.sph_fname, self.sph_fname))


### PR DESCRIPTION
This PR is intended to fix the summing dimension of image stack when >1 channel are used to generate masks. Each channel is thresholded first and then summed so the masks are not biased by the bright channel. The fix has been tested for 2D images but not 3D