### PR TITLE
Data normalization

### DIFF
--- a/micro_dl/cli/generate_meta.py
+++ b/micro_dl/cli/generate_meta.py
@@ -2,8 +2,9 @@
 
 import argparse
 import os
-
+import numpy as np
 import micro_dl.utils.aux_utils as aux_utils
+from micro_dl.utils.image_utils import read_image
 
 
 def parse_args():
@@ -72,7 +73,12 @@ def meta_generator(args):
             kwargs["order"] = args.order
         elif args.name_parser == 'parse_sms_name':
             kwargs["channel_names"] = channel_names
-        frames_meta.loc[i] = parse_func(**kwargs)
+        meta_row = parse_func(**kwargs)
+        im_path = os.path.join(args.input, im_names[i])
+        im = read_image(im_path)
+        meta_row['mean'] = np.nanmean(im)
+        meta_row['std'] = np.nanstd(im)
+        frames_meta.loc[i] = meta_row
 
     # Write metadata
     meta_filename = os.path.join(args.input, 'frames_meta.csv')

--- a/micro_dl/cli/image_inference.py
+++ b/micro_dl/cli/image_inference.py
@@ -333,10 +333,9 @@ def run_prediction(model_dir,
                 if save_figs:
                     # save predicted images assumes 2D
                     if depth > 1:
-                        im_stack = im_stack[..., 0, depth // 2, :, :]
-                        im_stack = im_stack[np.newaxis, ...]
-                        im_target = im_target[0, ...]
-                        im_pred = im_pred[0, ...]
+                        im_stack = im_stack[..., depth // 2, :, :]
+                        im_target = im_target[..., 0, :, :]
+                        im_pred = im_pred[..., 0, :, :]
                     plot_utils.save_predicted_images(
                         input_batch=im_stack,
                         target_batch=im_target,

--- a/micro_dl/cli/image_inference.py
+++ b/micro_dl/cli/image_inference.py
@@ -202,7 +202,6 @@ def run_prediction(model_dir,
     depth = 1
     if 'depth' in network_config:
         depth = network_config['depth']
-
     # Get input channel
     # TODO: Add multi channel support once such models are tested
     input_channel = dataset_config['input_channels']

--- a/micro_dl/cli/image_inference.py
+++ b/micro_dl/cli/image_inference.py
@@ -45,6 +45,21 @@ def parse_args():
         default=None,
         help='File name of weights in model dir (.hdf5). If None grab newest.',
     )
+
+    parser.add_argument(
+        '--save_to_image_dir',
+        dest='save_to_image_dir',
+        action='store_true',
+        help='write predicted images to image directory',
+    )
+
+    parser.add_argument(
+        '--save_to_model_dir',
+        dest='save_to_image_dir',
+        action='store_false',
+        help='write predicted images to model directory',
+    )
+    parser.set_defaults(save_to_model_dir=False)
     parser.add_argument(
         '--test_data',
         dest='test_data',
@@ -102,7 +117,8 @@ def run_prediction(model_dir,
                    metrics=None,
                    test_data=True,
                    ext='.tif',
-                   save_figs=False):
+                   save_figs=False,
+                   save_to_image_dir=False):
     """
     Predict images given model + weights.
     If the test_data flag is set to True, the test indices in
@@ -131,6 +147,14 @@ def run_prediction(model_dir,
         )
     # Load config file
     config_name = os.path.join(model_dir, 'config.yml')
+    # Create image subdirectory to write predicted images
+    if save_to_image_dir:
+        pred_dir = os.path.join(image_dir, os.path.basename(model_dir))
+        test_frames_meta_filename = os.path.join(image_dir, os.path.basename(model_dir), 'test_frames_meta.csv')
+    else:
+        pred_dir = os.path.join(model_dir, 'predictions')
+        test_frames_meta_filename = os.path.join(model_dir, 'test_frames_meta.csv')
+
     with open(config_name, 'r') as f:
         config = yaml.safe_load(f)
     # Load frames metadata and determine indices
@@ -146,10 +170,7 @@ def run_prediction(model_dir,
         index_col=0,
     )
     # TODO: generate test_frames_meta.csv together with tile csv during training
-    test_frames_meta_filename = os.path.join(
-        model_dir,
-        'test_frames_meta.csv',
-    )
+
     if metrics is not None:
         if isinstance(metrics, str):
             metrics = [metrics]

--- a/micro_dl/cli/image_inference.py
+++ b/micro_dl/cli/image_inference.py
@@ -59,7 +59,7 @@ def parse_args():
         action='store_false',
         help='write predicted images to model directory',
     )
-    parser.set_defaults(save_to_model_dir=False)
+    parser.set_defaults(save_to_image_dir=False)
     parser.add_argument(
         '--test_data',
         dest='test_data',
@@ -405,5 +405,6 @@ if __name__ == '__main__':
         test_data=args.test_data,
         ext=args.ext,
         save_figs=args.save_figs,
+        save_to_image_dir=args.save_to_image_dir,
     )
 

--- a/micro_dl/cli/preprocess_script.py
+++ b/micro_dl/cli/preprocess_script.py
@@ -192,7 +192,7 @@ def tile_images(params_dict,
               'int2str_len': params_dict['int2strlen']}
 
     if params_dict['uniform_struct']:
-        if 'tile_3d' in tile_dict:
+        if 'tile_3d' in tile_dict and tile_dict['tile_3d']:
             if resize_flag:
                 warnings.warn(
                     'If resize_3d was used, slice_idx corresponds to start'

--- a/micro_dl/config_preprocess.yml
+++ b/micro_dl/config_preprocess.yml
@@ -23,3 +23,4 @@ tile:
     image_format: 'zyx'
     save_tiled_masks: True
     min_fraction: 0.25
+    normalize_im: 'stack'

--- a/micro_dl/plotting/plot_utils.py
+++ b/micro_dl/plotting/plot_utils.py
@@ -54,8 +54,10 @@ def save_predicted_images(input_batch,
         
         n_ip_channels = cur_input.shape[0]
         n_op_channels = cur_target.shape[0]
-        n_rows = int(np.squrt((n_ip_channels+2*n_op_channels+1)/2))
-        n_cols = np.ceil((n_ip_channels+2*n_op_channels+1)/n_rows).astype(np.uint32)
+        n_subplot = n_ip_channels + 2 * n_op_channels + 1
+        # make aspect ratio = 1:1.6
+        n_rows = np.round(np.sqrt(n_subplot / 1.6)).astype(np.uint32)
+        n_cols = np.ceil(n_subplot / n_rows).astype(np.uint32)
         fig, ax = plt.subplots(n_rows, n_cols, squeeze=False)
         ax = ax.flatten()
         for axs in ax:

--- a/micro_dl/plotting/plot_utils.py
+++ b/micro_dl/plotting/plot_utils.py
@@ -54,8 +54,8 @@ def save_predicted_images(input_batch,
         
         n_ip_channels = cur_input.shape[0]
         n_op_channels = cur_target.shape[0]
-        n_cols = 3
-        n_rows = (n_ip_channels+2*n_op_channels)//n_cols+1
+        n_rows = int(np.squrt((n_ip_channels+2*n_op_channels+1)/2))
+        n_cols = np.ceil((n_ip_channels+2*n_op_channels+1)/n_rows).astype(np.uint32)
         fig, ax = plt.subplots(n_rows, n_cols, squeeze=False)
         ax = ax.flatten()
         for axs in ax:
@@ -73,21 +73,21 @@ def save_predicted_images(input_batch,
             ax[axis_count].set_title('Input', fontsize=font_size)
             axis_count += 1
         for channel_idx in range(n_op_channels):
-            cur_im = hist_clipping(
+            cur_target_chan = hist_clipping(
                 cur_target[channel_idx],
                 clip_limits,
                 100 - clip_limits,
             )
-            ax[axis_count].imshow(cur_im, cmap='gray')
+            ax[axis_count].imshow(cur_target_chan, cmap='gray')
             ax[axis_count].axis('off')
             ax[axis_count].set_title('Target', fontsize=font_size)
             axis_count += 1
-            cur_im = hist_clipping(
+            cur_pred_chan = hist_clipping(
                 cur_prediction[channel_idx],
                 clip_limits,
                 100 - clip_limits,
             )
-            ax[axis_count].imshow(cur_im, cmap='gray')
+            ax[axis_count].imshow(cur_pred_chan, cmap='gray')
             ax[axis_count].axis('off')
 
             ax[axis_count].set_title('Prediction', fontsize=font_size)

--- a/micro_dl/preprocessing/resize_images.py
+++ b/micro_dl/preprocessing/resize_images.py
@@ -141,7 +141,6 @@ class ImageResizer:
             sc_str = self.scale_factor
 
         mp_args = []
-        resized_metadata_list = []
         if num_slices_subvolume == -1:
             num_slices_subvolume = len(self.slice_ids)
         num_blocks = np.floor(
@@ -180,15 +179,9 @@ class ImageResizer:
                                         self.scale_factor,
                                         self.input_dir,
                                         ff_path))
-                        cur_metadata = {'time_idx': time_idx,
-                                        'pos_idx': pos_idx,
-                                        'channel_idx': channel_idx,
-                                        'slice_idx': start_idx,
-                                        'file_name': op_fname}
-                        resized_metadata_list.append(cur_metadata)
 
         # Multiprocessing of kwargs
-        mp_utils.mp_rescale_vol(mp_args, self.num_workers)
+        resized_metadata_list = mp_utils.mp_rescale_vol(mp_args, self.num_workers)
         resized_metadata_df = pd.DataFrame.from_dict(resized_metadata_list)
         resized_metadata_df.to_csv(
             os.path.join(self.resize_dir, 'frames_meta.csv'),

--- a/micro_dl/train/trainer.py
+++ b/micro_dl/train/trainer.py
@@ -91,10 +91,10 @@ class BaseKerasTrainer:
         for cb_dict in callbacks_config:
             cb_cls = getattr(keras_callbacks, cb_dict)
             if cb_dict == 'ModelCheckpoint':
-                if callbacks_config[cb_dict]['save_best_only']:
-                    assert callbacks_config[cb_dict]['monitor'] == 'val_loss',\
-                        'cannot checkpoint best_model if monitor' \
-                        'is not val_loss'
+                # if callbacks_config[cb_dict]['save_best_only']:
+                #     assert callbacks_config[cb_dict]['monitor'] == 'val_loss',\
+                #         'cannot checkpoint best_model if monitor' \
+                #         'is not val_loss'
                 timestamp = time.strftime("%Y-%m-%d-%H-%M-%S",
                                           time.localtime())
                 model_name = '{}_{}.hdf5'.format('Model', timestamp)

--- a/micro_dl/utils/aux_utils.py
+++ b/micro_dl/utils/aux_utils.py
@@ -159,6 +159,7 @@ def get_zscore_params(time_idx,
     :return float zscore_mean: mean for z-scoring the image
     :return float zscore_std: std for z-scoring the image
     """
+
     assert normalize_im in [None, 'stack', 'volume', 'dataset'], \
         'normalize_im must be None or "stack" or "volume" or "dataset"'
 
@@ -190,6 +191,7 @@ def get_zscore_params(time_idx,
                 pos_idx,
             )
             meta_idxs.append(meta_idx)
+    # Approximate stack and volume standard deviations with mean of slice standard deviations
     zscore_mean = frames_metadata.loc[meta_idxs, 'mean'].mean()
     zscore_std = frames_metadata.loc[meta_idxs, 'std'].mean()
     return zscore_mean, zscore_std

--- a/micro_dl/utils/aux_utils.py
+++ b/micro_dl/utils/aux_utils.py
@@ -136,6 +136,63 @@ def get_im_name(time_idx=None,
     im_name += ext
     return im_name
 
+def get_zscore_params(time_idx,
+                      channel_idx,
+                      slice_idx,
+                      pos_idx,
+                      depth,
+                      slice_ids,
+                      normalize_im,
+                      frames_metadata
+                      ):
+    """Get zscore mean and standard deviation
+
+    :param int time_idx: Time index
+    :param int channel_idx: Channel index
+    :param int slice_idx: Slice (z) index
+    :param int pos_idx: Position (FOV) index
+    :param int slice_ids: Index of which focal plane acquisition to
+         use (for 2D).
+    :param str mask_dir: Directory containing masks
+    :param None or str normalize_im: normalization scheme for input images
+    :param dataframe frames_metadata: metadata contains mean and std info of each z-slice
+    :return float zscore_mean: mean for z-scoring the image
+    :return float zscore_std: std for z-scoring the image
+    """
+    assert normalize_im in [None, 'stack', 'volume', 'dataset'], \
+        'normalize_im must be None or "stack" or "volume" or "dataset"'
+
+    margin = 0 if depth == 1 else depth // 2
+    if normalize_im is None:
+        # No normalization
+        zscore_mean = 0
+        zscore_std = 1
+        return zscore_mean, zscore_std
+
+    if normalize_im == 'dataset':
+        meta_idxs = get_row_idx(
+            frames_metadata,
+            time_idx,
+            channel_idx,
+        )
+    elif normalize_im in ['stack', 'volume']:
+        meta_idxs = []
+        if normalize_im == 'stack':
+            z_range = list(range(slice_idx - margin, slice_idx + margin + 1))
+        else:
+            z_range = slice_ids
+        for z in z_range:
+            meta_idx = get_meta_idx(
+                frames_metadata,
+                time_idx,
+                channel_idx,
+                z,
+                pos_idx,
+            )
+            meta_idxs.append(meta_idx)
+    zscore_mean = frames_metadata.loc[meta_idxs, 'mean'].mean()
+    zscore_std = frames_metadata.loc[meta_idxs, 'std'].mean()
+    return zscore_mean, zscore_std
 
 def sort_meta_by_channel(frames_metadata):
     """

--- a/micro_dl/utils/aux_utils.py
+++ b/micro_dl/utils/aux_utils.py
@@ -438,7 +438,7 @@ def write_json(json_dict, json_filename):
     :param dict json_dict: Dictionary to be written
     :param str json_filename: Full path file name of json
     """
-    json_dump = json.dumps(json_dict)
+    json_dump = json.dumps(json_dict, indent=4)
     with open(json_filename, "w") as write_file:
         write_file.write(json_dump)
 

--- a/micro_dl/utils/aux_utils.py
+++ b/micro_dl/utils/aux_utils.py
@@ -16,7 +16,9 @@ DF_NAMES = ["channel_idx",
             "time_idx",
             "channel_name",
             "file_name",
-            "pos_idx"]
+            "pos_idx",
+            "mean",
+            "std"]
 
 
 def import_object(module_name, obj_name, obj_type='class'):

--- a/micro_dl/utils/mp_utils.py
+++ b/micro_dl/utils/mp_utils.py
@@ -124,7 +124,10 @@ def tile_and_save(input_fnames,
                   image_format,
                   save_dir,
                   int2str_len=3,
-                  is_mask=False):
+                  is_mask=False,
+                  zscore_mean=None,
+                  zscore_std=None
+                  ):
     """Crop image into tiles at given indices and save
 
     :param tuple input_fnames: tuple of input fnames with full path
@@ -149,6 +152,9 @@ def tile_and_save(input_fnames,
             flat_field_fname=flat_field_fname,
             hist_clip_limits=hist_clip_limits,
             is_mask=is_mask,
+            normalize_im=True,
+            zscore_mean=zscore_mean,
+            zscore_std=zscore_std
         )
         save_dict = {'time_idx': time_idx,
                      'channel_idx': channel_idx,
@@ -202,7 +208,10 @@ def crop_at_indices_save(input_fnames,
                          save_dir,
                          int2str_len=3,
                          is_mask=False,
-                         tile_3d=False):
+                         tile_3d=False,
+                         zscore_mean=None,
+                         zscore_std=None
+                         ):
     """Crop image into tiles at given indices and save
 
     :param tuple input_fnames: tuple of input fnames with full path
@@ -227,6 +236,9 @@ def crop_at_indices_save(input_fnames,
             flat_field_fname=flat_field_fname,
             hist_clip_limits=hist_clip_limits,
             is_mask=is_mask,
+            normalize_im=True,
+            zscore_mean=zscore_mean,
+            zscore_std=zscore_std
         )
         save_dict = {'time_idx': time_idx,
                      'channel_idx': channel_idx,

--- a/micro_dl/utils/mp_utils.py
+++ b/micro_dl/utils/mp_utils.py
@@ -311,7 +311,8 @@ def mp_rescale_vol(fn_args, workers):
 
     with ProcessPoolExecutor(workers) as ex:
         # can't use map directly as it works only with single arg functions
-        ex.map(rescale_vol_and_save, *zip(*fn_args))
+        res = ex.map(rescale_vol_and_save, *zip(*fn_args))
+    return list(res)
 
 
 def rescale_vol_and_save(time_idx,
@@ -357,3 +358,12 @@ def rescale_vol_and_save(time_idx,
     input_stack = np.stack(input_stack, axis=2)
     resc_vol = image_utils.rescale_nd_image(input_stack, scale_factor)
     np.save(output_fname, resc_vol, allow_pickle=True, fix_imports=True)
+    cur_metadata = {'time_idx': time_idx,
+                    'pos_idx': pos_idx,
+                    'channel_idx': channel_idx,
+                    'slice_idx': sl_start_idx,
+                    'file_name': os.path.basename(output_fname),
+                    'mean': np.mean(resc_vol),
+                    'std': np.std(resc_vol)}
+    return cur_metadata
+

--- a/micro_dl/utils/normalize.py
+++ b/micro_dl/utils/normalize.py
@@ -3,7 +3,7 @@ import numpy as np
 from skimage.exposure import equalize_adapthist
 
 
-def zscore(input_image):
+def zscore(input_image, mean=None, std=None):
     """
     Performs z-score normalization. Adds epsilon in denominator for robustness
 
@@ -11,8 +11,12 @@ def zscore(input_image):
     :return: z score normalized image
     """
 
-    norm_img = (input_image - np.mean(input_image)) /\
-               (np.std(input_image) + np.finfo(float).eps)
+    if not mean:
+        mean = np.nanmean(input_image)
+    if not std:
+        std = np.nanstd(input_image)
+    norm_img = (input_image - mean) /\
+               (std + np.finfo(float).eps)
     return norm_img
 
 

--- a/micro_dl/utils/tile_utils.py
+++ b/micro_dl/utils/tile_utils.py
@@ -72,8 +72,7 @@ def preprocess_imstack(frames_metadata,
                        pos_idx,
                        flat_field_im=None,
                        hist_clip_limits=None,
-                       zscore_mean=0,
-                       zscore_std=1
+                       normalize_im='stack'
                        ):
     """
     Preprocess image given by indices: flatfield correction, histogram
@@ -88,10 +87,16 @@ def preprocess_imstack(frames_metadata,
     :param int pos_idx: Position (FOV) index
     :param np.array flat_field_im: Flat field image for channel
     :param list hist_clip_limits: Limits for histogram clipping (size 2)
-    :param bool normalize_im: indicator to z-score the image or not
+    :param str normalize_im: options to z-score the image
     :return np.array im: 3D preprocessed image
     """
 
+    metadata_ids, _ = aux_utils.validate_metadata_indices(
+        frames_metadata=frames_metadata,
+        slice_ids=-1,
+        uniform_structure=True
+    )
+    slice_ids = metadata_ids['slice_ids']
     margin = 0 if depth == 1 else depth // 2
     im_stack = []
     for z in range(slice_idx - margin, slice_idx + margin + 1):
@@ -128,6 +133,17 @@ def preprocess_imstack(frames_metadata,
             hist_clip_limits[0],
             hist_clip_limits[1],
         )
+
+    zscore_mean, zscore_std = aux_utils.get_zscore_params(
+        time_idx=time_idx,
+        channel_idx=channel_idx,
+        slice_idx=slice_idx,
+        pos_idx=pos_idx,
+        depth=depth,
+        slice_ids=slice_ids,
+        normalize_im=normalize_im,
+        frames_metadata=frames_metadata
+    )
 
     im_stack = normalize.zscore(
         im_stack, mean=zscore_mean,

--- a/micro_dl/utils/tile_utils.py
+++ b/micro_dl/utils/tile_utils.py
@@ -23,6 +23,8 @@ def read_imstack(input_fnames,
     :param tuple hist_clip_limits: limits for histogram clipping
     :param bool is_mask: Indicator for if files contain masks
     :param bool normalize_im: Whether to zscore normalize im stack
+    :param float zscore_mean: mean for z-scoring the image
+    :param float zscore_std: std for z-scoring the image
     :return np.array: input stack flat_field correct and z-scored if regular
         images, booleans if they're masks
     """

--- a/micro_dl/utils/tile_utils.py
+++ b/micro_dl/utils/tile_utils.py
@@ -11,7 +11,9 @@ def read_imstack(input_fnames,
                  flat_field_fname=None,
                  hist_clip_limits=None,
                  is_mask=False,
-                 normalize_im=True):
+                 normalize_im=True,
+                 zscore_mean=0,
+                 zscore_std=1):
     """
     Read the images in the fnames and assembles a stack.
     If images are masks, make sure they're boolean by setting >0 to True
@@ -51,7 +53,10 @@ def read_imstack(input_fnames,
                 hist_clip_limits[1]
             )
         if normalize_im:
-            input_image = normalize.zscore(input_image)
+            input_image = normalize.zscore(
+                input_image, mean=zscore_mean,
+                std=zscore_std
+            )
     else:
         if input_image.dtype != bool:
             input_image = input_image > 0
@@ -67,7 +72,9 @@ def preprocess_imstack(frames_metadata,
                        pos_idx,
                        flat_field_im=None,
                        hist_clip_limits=None,
-                       normalize_im=True):
+                       zscore_mean=0,
+                       zscore_std=1
+                       ):
     """
     Preprocess image given by indices: flatfield correction, histogram
     clipping and z-score normalization is performed.
@@ -121,8 +128,11 @@ def preprocess_imstack(frames_metadata,
             hist_clip_limits[0],
             hist_clip_limits[1],
         )
-    if normalize_im:
-        im_stack = normalize.zscore(im_stack)
+
+    im_stack = normalize.zscore(
+        im_stack, mean=zscore_mean,
+        std=zscore_std
+    )
     return im_stack
 
 

--- a/tests/cli/preprocess_script_tests.py
+++ b/tests/cli/preprocess_script_tests.py
@@ -38,10 +38,14 @@ class TestPreprocessScript(unittest.TestCase):
                         pos_idx=p,
                         ext='.png',
                     )
+                    im = self.im + c * 100
                     cv2.imwrite(os.path.join(self.temp_path, im_name),
-                                self.im + c * 100)
+                                im)
+                    meta_row = aux_utils.parse_idx_from_name(im_name)
+                    meta_row['mean'] = np.nanmean(im)
+                    meta_row['std'] = np.nanstd(im)
                     self.frames_meta = self.frames_meta.append(
-                        aux_utils.parse_idx_from_name(im_name),
+                        meta_row,
                         ignore_index=True,
                     )
         # Write metadata

--- a/tests/preprocessing/resize_images_tests.py
+++ b/tests/preprocessing/resize_images_tests.py
@@ -140,7 +140,9 @@ class TestResizeImages(unittest.TestCase):
                                   'pos_idx': self.pos_idx,
                                   'channel_idx': c,
                                   'slice_idx': 0,
-                                  'file_name': op_fname})
+                                  'file_name': op_fname,
+                                  'mean': np.mean(self.im) + c * 100,
+                                  'std': float(0)})
         # Write metadata
         frames_meta.to_csv(
             os.path.join(self.temp_path, self.meta_name),
@@ -173,7 +175,9 @@ class TestResizeImages(unittest.TestCase):
                                       'pos_idx': self.pos_idx,
                                       'channel_idx': c,
                                       'slice_idx': s,
-                                      'file_name': op_fname})
+                                      'file_name': op_fname,
+                                      'mean': np.mean(self.im) + c * 100,
+                                      'std': float(0)})
 
         resize_inst.resize_volumes(num_slices_subvolume=3)
         saved_meta = pd.read_csv(os.path.join(self.output_dir,

--- a/tests/preprocessing/tile_uniform_images_tests.py
+++ b/tests/preprocessing/tile_uniform_images_tests.py
@@ -30,6 +30,7 @@ class TestImageTilerUniform(unittest.TestCase):
         self.pos_idx1 = 7
         self.pos_idx2 = 8
         self.int2str_len = 3
+        self.normalize_im = None
 
         # Write test images with 4 z and 2 pos idx
         for z in range(15, 20):
@@ -110,6 +111,7 @@ class TestImageTilerUniform(unittest.TestCase):
             output_dir=self.output_dir,
             tile_dict=self.tile_dict,
             flat_field_dir=self.flat_field_dir,
+            normalize_im=self.normalize_im,
         )
         exp_fnames = ['im_c001_z015_t005_p007.png',
                       'im_c001_z016_t005_p007.png',
@@ -156,7 +158,6 @@ class TestImageTilerUniform(unittest.TestCase):
                             [4, 9, 0, 5], [4, 9, 4, 9], [4, 9, 6, 11],
                             [8, 13, 0, 5], [8, 13, 4, 9], [8, 13, 6, 11]]
         self.exp_tile_indices = exp_tile_indices
-        print(frames_meta)
     def tearDown(self):
         """Tear down temporary folder and file structure"""
 
@@ -350,9 +351,9 @@ class TestImageTilerUniform(unittest.TestCase):
         self.assertSetEqual(set(frames_meta.col_start.tolist()), {0, 4, 6})
 
         # Read and validate tiles
-        im_val = np.mean(norm_util.zscore(self.im / self.ff_im))
+        im_val = np.mean(norm_util.zscore(self.im / self.ff_im, mean=0, std=1))
         im_norm = im_val * np.ones((3, 5, 5))
-        im_val = np.mean(norm_util.zscore(self.im2 / self.ff_im))
+        im_val = np.mean(norm_util.zscore(self.im2 / self.ff_im, mean=0, std=1))
         im2_norm = im_val * np.ones((3, 5, 5))
         for i, row in frames_meta.iterrows():
             tile = np.load(os.path.join(tile_dir, row.file_name))

--- a/tests/preprocessing/tile_uniform_images_tests.py
+++ b/tests/preprocessing/tile_uniform_images_tests.py
@@ -46,9 +46,13 @@ class TestImageTilerUniform(unittest.TestCase):
                     os.path.join(self.temp_path, im_name),
                     self.im,
                 )
+            meta_row = aux_utils.parse_idx_from_name(
+                im_name)
+            meta_row['mean'] = np.nanmean(self.im)
+            meta_row['std'] = np.nanstd(self.im)
             frames_meta = frames_meta.append(
-                aux_utils.parse_idx_from_name(im_name),
-                ignore_index=True,
+                meta_row,
+                ignore_index=True
             )
 
         for z in range(15, 20):
@@ -65,9 +69,13 @@ class TestImageTilerUniform(unittest.TestCase):
                     os.path.join(self.temp_path, im_name),
                     self.im2,
                 )
+            meta_row = aux_utils.parse_idx_from_name(
+                im_name)
+            meta_row['mean'] = np.nanmean(self.im2)
+            meta_row['std'] = np.nanstd(self.im2)
             frames_meta = frames_meta.append(
-                aux_utils.parse_idx_from_name(im_name),
-                ignore_index=True,
+                meta_row,
+                ignore_index=True
             )
 
         # Write metadata
@@ -148,7 +156,7 @@ class TestImageTilerUniform(unittest.TestCase):
                             [4, 9, 0, 5], [4, 9, 4, 9], [4, 9, 6, 11],
                             [8, 13, 0, 5], [8, 13, 4, 9], [8, 13, 6, 11]]
         self.exp_tile_indices = exp_tile_indices
-
+        print(frames_meta)
     def tearDown(self):
         """Tear down temporary folder and file structure"""
 

--- a/tests/utils/tile_utils_tests.py
+++ b/tests/utils/tile_utils_tests.py
@@ -59,8 +59,12 @@ class TestTileUtils(unittest.TestCase):
                     os.path.join(self.temp_path, im_name),
                     sph[:, :, z],
                 )
+            meta_row = aux_utils.parse_idx_from_name(
+                im_name, self.df_columns)
+            meta_row['mean'] = np.nanmean(sph)
+            meta_row['std'] = np.nanstd(sph)
             frames_meta = frames_meta.append(
-                aux_utils.parse_idx_from_name(im_name, self.df_columns),
+                meta_row,
                 ignore_index=True
             )
 


### PR DESCRIPTION
This PR added different data normalization options for pre-processing. It doesn't work for flat-field correction at the moment because flat-field correction is applied to each stack right before tiling and it changes z-score parameters. One solution would be creating a directory with flat-field corrected images upfront and run subsequent preprocessing and inference from there rather than from the original image directory. I think that would also simply the code as everything needs to be run on flat-field corrected images anyway.    