### PR TITLE
fix inference 2.5D model bug

### DIFF
--- a/micro_dl/inference/image_inference.py
+++ b/micro_dl/inference/image_inference.py
@@ -704,7 +704,7 @@ class ImagePredictor:
                     step_size=step_size,
                     return_index=True
                 )
-                print('crop_indices:' , crop_indices)
+                print('crop_indices:', crop_indices)
                 pred_block_list = self._predict_sub_block_xy(
                     cur_input,
                     crop_indices,
@@ -745,10 +745,17 @@ class ImagePredictor:
             target_stack.append(cur_target.astype(np.float32))
         pred_stack = np.concatenate(pred_stack, axis=0) #zcyx
         target_stack = np.concatenate(target_stack, axis=0)
+
         # Stack images and transpose (metrics assumes cyxz format)
         if self.image_format == 'zyx':
-            pred_stack = np.transpose(pred_stack, [1, 2, 3, 0])
-            target_stack = np.transpose(target_stack, [1, 2, 3, 0])
+            if len(np.shape(pred_stack)) == 4:
+                pred_stack = np.transpose(pred_stack, [1, 2, 3, 0])
+                target_stack = np.transpose(target_stack, [1, 2, 3, 0])
+            else:
+                pred_stack = pred_stack[:, :, 0, :, :]
+                pred_stack = np.transpose(pred_stack, [1, 2, 3, 0])
+                target_stack = target_stack[:, :, 0, :, :]
+                target_stack = np.transpose(target_stack, [1, 2, 3, 0])
         if self.mask_metrics:
             mask_stack = np.concatenate(mask_stack, axis=0)
             if self.image_format == 'zyx':


### PR DESCRIPTION
Related to #138 

2.5D model inference runs through by adapting the dimensionality of the pred_stack variable in (infernce->image_inference.py->predict_2d()). The variable has the shape (ZC?YX) and dropping the unknown dimension fixes the issue and predictions are successfully saved. The code is tested for 2.5D model single channel, 2.5D model multi channel & 2D model single channel (model path details are linked in issue). However, I could not figure out the meaning of the unknown dimension and it should be check if it is save to drop it!