### PR TITLE
Inference bug, pandas docker version

### DIFF
--- a/micro_dl/utils/aux_utils.py
+++ b/micro_dl/utils/aux_utils.py
@@ -184,7 +184,7 @@ def get_sms_im_name(time_idx=None,
     This function is custom for the computational microscopy (SMS)
     group, who has the following file naming convention:
     File naming convention is assumed to be:
-        img_channelname_t***_p***_z***.tif
+        img_channelname_t***_p***_z***_extrafield.tif
     This function will alter list and dict in place.
 
     :param int time_idx: Time index
@@ -194,7 +194,7 @@ def get_sms_im_name(time_idx=None,
     :param str extra_field: Any extra string you want to include in the name
     :param str ext: Extension, e.g. '.png'
     :param int int2str_len: Length of string of the converted integers
-    :return st im_name: Image file name
+    :return str im_name: Image file name
     """
 
     im_name = "img"

--- a/micro_dl/utils/aux_utils.py
+++ b/micro_dl/utils/aux_utils.py
@@ -198,7 +198,7 @@ def get_sms_im_name(time_idx=None,
     """
 
     im_name = "img"
-    if channel_name is not None:
+    if not pd.isnull(channel_name):
         im_name += "_" + str(channel_name)
     if time_idx is not None:
         im_name += "_t" + str(time_idx).zfill(int2str_len)

--- a/micro_dl/utils/aux_utils.py
+++ b/micro_dl/utils/aux_utils.py
@@ -198,7 +198,7 @@ def get_sms_im_name(time_idx=None,
     """
 
     im_name = "img"
-    if np.isnan(channel_name):
+    if channel_name is not None:
         im_name += "_" + str(channel_name)
     if time_idx is not None:
         im_name += "_t" + str(time_idx).zfill(int2str_len)

--- a/requirements_docker.txt
+++ b/requirements_docker.txt
@@ -4,7 +4,7 @@ natsort==6.0.0
 nose==1.3.7
 numpy==1.21.0
 opencv-python==4.4.0.40
-pandas==1.1.5
+pandas==0.24.2
 protobuf==3.20.1
 pydot==1.4.1
 PyYAML>=5.4

--- a/tests/utils/aux_utils_tests.py
+++ b/tests/utils/aux_utils_tests.py
@@ -94,6 +94,7 @@ def test_get_im_name():
     )
     nose.tools.assert_equal(im_name, 'im_c2_z3_t1_p4_hej.png')
 
+
 def test_get_sms_im_name():
     im_name = aux_utils.get_sms_im_name(
         time_idx=0,
@@ -115,6 +116,7 @@ def test_get_sms_im_name():
         int2str_len=2,
     )
     nose.tools.assert_equal(im_name, 'img_t00_p10.jpg')
+
 
 def test_get_im_name_default():
     im_name = aux_utils.get_im_name()

--- a/tests/utils/aux_utils_tests.py
+++ b/tests/utils/aux_utils_tests.py
@@ -106,6 +106,9 @@ def test_get_sms_im_name():
         int2str_len=3,
     )
     nose.tools.assert_equal(im_name, 'img_phase_t000_p100_z010_blub.png')
+
+
+def test_get_sms_im_name_nones():
     im_name = aux_utils.get_sms_im_name(
         time_idx=0,
         channel_name=None,

--- a/tests/utils/aux_utils_tests.py
+++ b/tests/utils/aux_utils_tests.py
@@ -94,6 +94,27 @@ def test_get_im_name():
     )
     nose.tools.assert_equal(im_name, 'im_c2_z3_t1_p4_hej.png')
 
+def test_get_sms_im_name():
+    im_name = aux_utils.get_sms_im_name(
+        time_idx=0,
+        channel_name='phase',
+        slice_idx=10,
+        pos_idx=100,
+        extra_field='blub',
+        ext='.png',
+        int2str_len=3,
+    )
+    nose.tools.assert_equal(im_name, 'img_phase_t000_p100_z010_blub.png')
+    im_name = aux_utils.get_sms_im_name(
+        time_idx=0,
+        channel_name=None,
+        slice_idx=None,
+        pos_idx=10,
+        extra_field=None,
+        ext='.jpg',
+        int2str_len=2,
+    )
+    nose.tools.assert_equal(im_name, 'img_t00_p10.jpg')
 
 def test_get_im_name_default():
     im_name = aux_utils.get_im_name()


### PR DESCRIPTION
**Inference bug**
Hi, I get an error when running inference with the latest version of the repo (master branch, #da7dcfc). The variable "channel_name" is automatically extracted from the meta_data in ["inference->image_inference"](https://github.com/czbiohub/microDL/blob/da7dcfc0c400195e211c525175d5380049ffb0d2/micro_dl/inference/image_inference.py#L541) and the "channel_name" info is used in the name of the saved images (["utils->aux_utils".](https://github.com/czbiohub/microDL/blob/da7dcfc0c400195e211c525175d5380049ffb0d2/micro_dl/utils/aux_utils.py#L201
))

The channel_name variable (str) is checked by the statement np.isnan(channel_name), which gives an error. 
```
if np.isnan(channel_name):
    im_name += "_" + str(channel_name)
```

I changed the line to:
```
if channel_name is not None:
    im_name += "_" + str(channel_name)
```
- no error when checking for channel_name value
- if a channel name is defined, the name will be inserted in the name of the saved images


Command: `python /home/pwrai/microDL/microDL/micro_dl/cli/inference_script.py --config /gpfs/CompMicro/projects/virtualstaining/2022_microDL_nuc_mem/configfiles/input_mem/config_inference_2022_03_15_mem_heavy_augmentation_test_40x_error.yml --gpu 3`

Configfile (you can use this file to try out the inference): `/gpfs/CompMicro/projects/virtualstaining/2022_microDL_nuc_mem/configfiles/input_mem/config_inference_2022_03_15_mem_heavy_augmentation_z12-74_test_40x.yml`

MicroDL was executed in docker (image: microdl_sguo, name: microDL_JR) on hulk.

The inference branch was checked out from master #da7dcfc

Error:
<img width="791" alt="image" src="https://user-images.githubusercontent.com/48733135/171867774-8919b629-4fb2-491e-9edb-4287b3afbc85.png">

**Pandas version in docker**
The pandas version must be set to 0.24.2, with 1.1.5 there are interferences with the numpy library. I downgraded the version in the requirements_docker.txt file to prevent the error.

Command: `python /home/pwrai/microDL/microDL/micro_dl/cli/inference_script.py --config /gpfs/CompMicro/projects/virtualstaining/2022_microDL_nuc_mem/configfiles/input_mem/config_inference_2022_03_15_mem_heavy_augmentation_test_40x_error.yml --gpu 3`

Error:
<img width="791" alt="image" src="https://user-images.githubusercontent.com/48733135/171868314-5ba9ab90-23e6-4413-ad9b-bfa08d8370ae.png">


