### PR TITLE
fix preprocess metadata keyerror bug

### DIFF
--- a/micro_dl/cli/preprocess_script.py
+++ b/micro_dl/cli/preprocess_script.py
@@ -497,15 +497,16 @@ def pre_process(preprocess_config):
     # -------Compute intensities for flatfield corrected images-------
     if required_params['normalize_im'] in ['dataset', 'volume', 'slice']:
         block_size = None
-        if 'block_size' in preprocess_config['metadata']:
-            block_size = preprocess_config['metadata']['block_size']
-        meta_utils.ints_meta_generator(
-            input_dir=required_params['input_dir'],
-            num_workers=required_params['num_workers'],
-            block_size=block_size,
-            flat_field_dir=flat_field_dir,
-            channel_ids=required_params['channel_ids'],
-        )
+        if 'metadata' in preprocess_config:
+            if 'block_size' in preprocess_config['metadata']:
+                block_size = preprocess_config['metadata']['block_size']
+            meta_utils.ints_meta_generator(
+                input_dir=required_params['input_dir'],
+                num_workers=required_params['num_workers'],
+                block_size=block_size,
+                flat_field_dir=flat_field_dir,
+                channel_ids=required_params['channel_ids'],
+            )
 
     # -------------------------Resize images--------------------------
     if 'resize' in preprocess_config:


### PR DESCRIPTION
Hi,

missing `‘metadata’` in the preprocess yml file gives a keyerror in the current repo. This PR makes the definition of `‘metadata’` optional, which gives the user more flexibility. For example, I do not need flat field correction for my current workflow. Let me know what you think!

Best,
Johanna

Errormessage: 
<img width="785" alt="image" src="https://user-images.githubusercontent.com/48733135/178112332-183e55dd-ef06-4a37-b6b4-fc43ed7a52e9.png">

Command: 
`python /home/pwrai/microDL/microDL/micro_dl/cli/preprocess_script.py --config /gpfs/CompMicro/projects/virtualstaining/2022_microDL_nuc_mem/preprocess/infected_cells/TICM0026/config_preprocess_TICM0026_nuc_mem_z12-74.yml`
